### PR TITLE
Add ENV override for all configurations

### DIFF
--- a/confd/templates/utserver.conf.tmpl
+++ b/confd/templates/utserver.conf.tmpl
@@ -138,7 +138,7 @@ dir_download: {{.}}
 ## The value of this setting will be applied every time the utserver process
 ## starts or the configuration file is reloaded.
 
-dir_torrent_files: {{toLower (getenv "dir_torrent_files" "/utorrent/torrents")}}
+dir_torrent_files: {{getenv "dir_torrent_files" "/utorrent/torrents"}}
 ## dir_torrent_files (string):
 ## Default value: "". Directory where torrent files are stored. If the empty
 ## string, the value of dir_active is used. It is recommended that this

--- a/confd/templates/utserver.conf.tmpl
+++ b/confd/templates/utserver.conf.tmpl
@@ -241,7 +241,7 @@ rate_limit_local_peers: {{toLower (getenv "rate_limit_local_peers" "false")}}
 ## Default value: false. If true, rate limiting also applies to communications
 ## with peers in the local subnet. We recommend setting this value to false.
 
-dir_root:  {{toLower (getenv "dir_root" "/data")}}
+dir_root:  {{getenv "dir_root" "/data"}}
 ## dir_root (string):
 ## Default value: "". If not empty, dir_active, dir_completed, and
 ## dir_torrent_files are relative to this directory.

--- a/confd/templates/utserver.conf.tmpl
+++ b/confd/templates/utserver.conf.tmpl
@@ -109,7 +109,7 @@ dir_active: {{getenv "dir_active" "/data"}}
 ## is not defined or an empty string. It is recommended that this directory be
 ## hidden from users (i.e. not exported through Samba).
 
-dir_completed: {{toLower (getenv "dir_completed" "/data")}}
+dir_completed: {{getenv "dir_completed" "/data"}}
 ## dir_completed (string):
 ## Default value: "". Directory where completed downloads are stored. If the
 ## value is an empty string, the value of dir_active is used. This value must

--- a/confd/templates/utserver.conf.tmpl
+++ b/confd/templates/utserver.conf.tmpl
@@ -169,7 +169,7 @@ dir_autoload_delete: {{toLower (getenv "dir_autoload_delete" "false")}}
 ## of .loaded. The dir_autoload setting must be specified for this setting to
 ## have an effect.
 
-dir_request: {{toLower (getenv "dir_request" "/utorrent/request")}}
+dir_request: {{getenv "dir_request" "/utorrent/request"}}
 ## dir_request (string):
 ## Default value: "". Directory where maintenance request files will be
 ## recognized, loaded, and deleted. If the empty string, maintenance request

--- a/confd/templates/utserver.conf.tmpl
+++ b/confd/templates/utserver.conf.tmpl
@@ -101,7 +101,7 @@ token_auth_enable: {{toLower (getenv "token_auth_enable" "true")}}
 ## the parameter list of any request made to that interface. If false, the
 ## µTorrent HTTP interface will not be protected in this manner.
 
-dir_active: /data
+dir_active: {{toLower (getenv "dir_active" "/data")}}
 ## dir_active (string):
 ## Default value: "./". Directory in which currently downloaded data is saved.
 ## Can be an absolute path or a relative path. If it is a relative path, the
@@ -109,7 +109,7 @@ dir_active: /data
 ## is not defined or an empty string. It is recommended that this directory be
 ## hidden from users (i.e. not exported through Samba).
 
-dir_completed: /data
+dir_completed: {{toLower (getenv "dir_completed" "/data")}}
 ## dir_completed (string):
 ## Default value: "". Directory where completed downloads are stored. If the
 ## value is an empty string, the value of dir_active is used. This value must
@@ -117,7 +117,7 @@ dir_completed: /data
 ## It also has to be on the same volume as dir_active.
 
 {{ range (split (getenv "dir_download" "") ",") }}
-dir_download: /data/{{.}}
+dir_download: {{.}}
 {{- end }}
 ## dir_download (string):
 ## Default value: "". Optional directory where completed downloads can be
@@ -138,13 +138,13 @@ dir_download: /data/{{.}}
 ## The value of this setting will be applied every time the utserver process
 ## starts or the configuration file is reloaded.
 
-dir_torrent_files: /utorrent/torrents
+dir_torrent_files: {{toLower (getenv "dir_torrent_files" "/utorrent/torrents")}}
 ## dir_torrent_files (string):
 ## Default value: "". Directory where torrent files are stored. If the empty
 ## string, the value of dir_active is used. It is recommended that this
 ## directory be hidden from users (i.e. not exported through Samba).
 
-dir_temp_files: /utorrent/temp
+dir_temp_files: {{toLower (getenv "dir_temp_files" "/utorrent/temp")}}
 ## dir_temp_files (string):
 ## Default value: "". Directory where temporary files are stored. If the empty
 ## string, the value of dir_active is used. It is recommended that this
@@ -157,7 +157,7 @@ dir_temp_files: /utorrent/temp
 ## to POSIX systems. The value should specify a directory, not a symbolic link
 ## to a directory.
 
-dir_autoload: /utorrent/autoload
+dir_autoload: {{toLower (getenv "dir_autoload" "/utorrent/autoload")}}
 ## dir_autoload (string):
 ## Default value: "". Directory where torrent files will be recognized and
 ## auto-loaded. If the empty string, auto-load is disabled.
@@ -169,7 +169,7 @@ dir_autoload_delete: {{toLower (getenv "dir_autoload_delete" "false")}}
 ## of .loaded. The dir_autoload setting must be specified for this setting to
 ## have an effect.
 
-dir_request: /utorrent/request
+dir_request: {{toLower (getenv "dir_request" "/utorrent/request")}}
 ## dir_request (string):
 ## Default value: "". Directory where maintenance request files will be
 ## recognized, loaded, and deleted. If the empty string, maintenance request
@@ -241,7 +241,7 @@ rate_limit_local_peers: {{toLower (getenv "rate_limit_local_peers" "false")}}
 ## Default value: false. If true, rate limiting also applies to communications
 ## with peers in the local subnet. We recommend setting this value to false.
 
-dir_root: /data
+dir_root:  {{toLower (getenv "dir_root" "/data")}}
 ## dir_root (string):
 ## Default value: "". If not empty, dir_active, dir_completed, and
 ## dir_torrent_files are relative to this directory.
@@ -482,7 +482,7 @@ all_writes_sync: {{toLower (getenv "all_writes_sync" "false")}}
 ## for synchronous I/O disk space for a torrent is allocated before the first
 ## piece is written to disk. This value is always applied from utserver.conf.
 
-randomize_bind_port: false
+randomize_bind_port: {{toLower (getenv "randomize_bind_port" "false")}}
 ## randomize_bind_port (boolean):
 ## Default value: false. If true, a random port will be chosen as the peer
 ## port at startup, even if the user has chosen a different peer port during

--- a/confd/templates/utserver.conf.tmpl
+++ b/confd/templates/utserver.conf.tmpl
@@ -101,7 +101,7 @@ token_auth_enable: {{toLower (getenv "token_auth_enable" "true")}}
 ## the parameter list of any request made to that interface. If false, the
 ## µTorrent HTTP interface will not be protected in this manner.
 
-dir_active: {{toLower (getenv "dir_active" "/data")}}
+dir_active: {{getenv "dir_active" "/data"}}
 ## dir_active (string):
 ## Default value: "./". Directory in which currently downloaded data is saved.
 ## Can be an absolute path or a relative path. If it is a relative path, the

--- a/confd/templates/utserver.conf.tmpl
+++ b/confd/templates/utserver.conf.tmpl
@@ -157,7 +157,7 @@ dir_temp_files: {{getenv "dir_temp_files" "/utorrent/temp"}}
 ## to POSIX systems. The value should specify a directory, not a symbolic link
 ## to a directory.
 
-dir_autoload: {{toLower (getenv "dir_autoload" "/utorrent/autoload")}}
+dir_autoload: {{getenv "dir_autoload" "/utorrent/autoload"}}
 ## dir_autoload (string):
 ## Default value: "". Directory where torrent files will be recognized and
 ## auto-loaded. If the empty string, auto-load is disabled.

--- a/confd/templates/utserver.conf.tmpl
+++ b/confd/templates/utserver.conf.tmpl
@@ -144,7 +144,7 @@ dir_torrent_files: {{toLower (getenv "dir_torrent_files" "/utorrent/torrents")}}
 ## string, the value of dir_active is used. It is recommended that this
 ## directory be hidden from users (i.e. not exported through Samba).
 
-dir_temp_files: {{toLower (getenv "dir_temp_files" "/utorrent/temp")}}
+dir_temp_files: {{getenv "dir_temp_files" "/utorrent/temp"}}
 ## dir_temp_files (string):
 ## Default value: "". Directory where temporary files are stored. If the empty
 ## string, the value of dir_active is used. It is recommended that this


### PR DESCRIPTION
This PR adds the possibility to override all configurations done over the `utserver.conf`. 
Even though many may not have any effect if the `settings.dat` file exists, they may be useful for the initial boot.

It also changes the `dir_download` configuration to allow supplying folders outside of `/data` (the example stated on the docker hub readme (`dir_download: subdir1,/abs-path-dir`) will not yield the expected results.